### PR TITLE
Add Docker setup and sample data script for Ansimaq

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ ERPNext is built on the [Frappe Framework](https://github.com/frappe/frappe), a 
 ### Containerized Installation
 
 Use docker to deploy ERPNext in production or for development of [Frappe](https://github.com/frappe/frappe) apps. See https://github.com/frappe/frappe_docker for more details.
+For a quick example using docker compose and sample data for **Ansimaq**, check [docs/setup_ansimaq_docker_es.md](docs/setup_ansimaq_docker_es.md).
 
 ### Full Install
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3.8'
+
+services:
+  mariadb:
+    image: mariadb:10.6
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+    volumes:
+      - mariadb-data:/var/lib/mysql
+
+  redis:
+    image: redis:alpine
+
+  frappe:
+    image: frappe/bench:latest
+    command: >
+      bash -c "\
+        if [ ! -d sites/ansimaq.local ]; then \
+          bench new-site ansimaq.local --admin-password admin --mariadb-root-password root && \
+          bench --site ansimaq.local install-app erpnext; \
+        fi && \
+        bench start"
+    volumes:
+      - ./sites:/home/frappe/frappe-bench/sites
+      - ./scripts:/home/frappe/frappe-bench/scripts
+    ports:
+      - '8000:8000'
+    depends_on:
+      - mariadb
+      - redis
+
+volumes:
+  mariadb-data:

--- a/docs/setup_ansimaq_docker_es.md
+++ b/docs/setup_ansimaq_docker_es.md
@@ -1,0 +1,26 @@
+# Entorno Docker para ERPNext y Ansimaq
+
+Esta guía explica cómo iniciar ERPNext en contenedores utilizando **docker compose** y cómo poblar una base de datos de ejemplo para la empresa **Ansimaq**.
+
+## Requisitos previos
+
+- Docker y docker compose instalados en el sistema.
+
+## 1. Preparación
+
+1. Clona este repositorio y ubícate en la carpeta raiz.
+2. Ejecuta `docker compose up` para descargar las imágenes y crear los contenedores.
+3. La primera vez se creará un sitio llamado `ansimaq.local` con la contraseña de administrador `admin` y la de MariaDB `root`.
+4. Una vez completado el proceso, ERPNext quedará disponible en `http://localhost:8000`.
+
+## 2. Poblar datos de ejemplo
+
+Para agregar algunos registros de demostración ejecuta la consola de frappe dentro del contenedor:
+
+```bash
+docker compose exec frappe bench --site ansimaq.local execute scripts.ansimaq_populate.run
+```
+
+Este comando creará un cliente, un artículo y una factura de ejemplo.
+
+Con esto el front-end y el back-end quedarán listos para probar la instalación de **Ansimaq** usando contenedores.

--- a/scripts/ansimaq_populate.py
+++ b/scripts/ansimaq_populate.py
@@ -1,0 +1,25 @@
+import frappe
+
+def run():
+    frappe.get_doc({
+        "doctype": "Customer",
+        "customer_name": "Ansimaq S.A.",
+        "customer_type": "Company",
+    }).insert()
+
+    frappe.get_doc({
+        "doctype": "Item",
+        "item_code": "ANS-001",
+        "item_name": "Servicio Demo",
+        "stock_uom": "Unit",
+    }).insert()
+
+    invoice = frappe.get_doc({
+        "doctype": "Sales Invoice",
+        "customer": "Ansimaq S.A.",
+        "items": [{"item_code": "ANS-001", "qty": 1, "rate": 100}],
+    })
+    invoice.insert()
+    frappe.db.commit()
+
+


### PR DESCRIPTION
## Summary
- add docker compose config for ERPNext
- provide sample population script for Ansimaq
- document Docker-based setup steps for Ansimaq
- reference the new documentation in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ec621c1d48320b946ba0420c803e2